### PR TITLE
Update install instructions for new slack version

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,11 +5,11 @@
 1. Copy the values below:
 
 ```css
-#282A36,#44475A,#44475A,#8BE9FD,#6272A4,#FFFFFF,#50FA7B,#FF5555
+#282A36,#44475A,#44475A,#8BE9FD,#6272A4,#FFFFFF,#50FA7B,#FF5555,#44475A,#44475A
 ```
 
-2. In **Slack**, go to `File > Preferences > Themes`;
-3. Select `Dark` in `Appearance` section;
-4. In `Colors` section, click on `Import theme`;
+2. In **Slack**, go to `Settings > Themes`;
+3. Select `Dark` in `Colour Mode` section;
+4. In `Theme Colors` section, click on `Import theme`;
 5. Paste the colors you copied from the previous step in the textbox;
 6. Enjoy Dracula theme in Slack! 💜


### PR DESCRIPTION
On Slack version 4.34.121 the current install instructions are not working. The reason is that with the new update, Slack expects 10 colour values rather than 8. By adding two more values to the original list, you get the theme back.